### PR TITLE
add command that print version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 
 .envrc
 _tmp/
+artifacts/packer-post-processor-vagrant-metadata_*

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ARTIFACTS_DIR:=$(CURDIR)/artifacts
 
 VERSION=$(shell gobump show | jq -r .version)
 COMMIT=$(shell git rev-parse --verify HEAD)
-BUILD_FLAGS=-ldflags "-X main.version=\"$(VERSION)\" -X main.GitCommit=\"$(COMMIT)\""
+BUILD_FLAGS=-ldflags "-X main.Version=\"$(VERSION)\" -X main.GitCommit=\"$(COMMIT)\""
 GOOS:=linux darwin windows
 GOARCH:=amd64
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@
 ARTIFACTS_DIR:=$(CURDIR)/artifacts
 
 VERSION=$(shell gobump show | jq -r .version)
-BUILD_FLAGS=-ldflags "-X main.Version \"v$(VERSION)\""
+COMMIT=$(shell git rev-parse --verify HEAD)
+BUILD_FLAGS=-ldflags "-X main.version=\"$(VERSION)\" -X main.GitCommit=\"$(COMMIT)\""
 GOOS:=linux darwin windows
 GOARCH:=amd64
 

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/YOwatari/packer-post-processor-vagrant-metadata/command"
+	"github.com/mitchellh/cli"
+)
+
+func Run(args []string) int {
+
+	// Meta-option for executables.
+	// It defines output color and its stdout/stderr stream.
+	meta := &command.Meta{
+		Ui: &cli.ColoredUi{
+			InfoColor:  cli.UiColorBlue,
+			ErrorColor: cli.UiColorRed,
+			Ui: &cli.BasicUi{
+				Writer:      os.Stdout,
+				ErrorWriter: os.Stderr,
+				Reader:      os.Stdin,
+			},
+		}}
+
+	return RunCustom(args, Commands(meta))
+}
+
+func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
+
+	// Get the command line args. We shortcut "--version" and "-v" to
+	// just show the version.
+	for _, arg := range args {
+		if arg == "-v" || arg == "-version" || arg == "--version" {
+			newArgs := make([]string, len(args)+1)
+			newArgs[0] = "version-number"
+			copy(newArgs[1:], args)
+			args = newArgs
+			break
+		}
+	}
+
+	cli := &cli.CLI{
+		Args:       args,
+		Commands:   commands,
+		Version:    version,
+		HelpFunc:   cli.BasicHelpFunc(Name),
+		HelpWriter: os.Stdout,
+	}
+
+	exitCode, err := cli.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to execute: %s\n", err.Error())
+	}
+
+	return exitCode
+}

--- a/cli.go
+++ b/cli.go
@@ -43,7 +43,7 @@ func RunCustom(args []string, commands map[string]cli.CommandFactory) int {
 	cli := &cli.CLI{
 		Args:       args,
 		Commands:   commands,
-		Version:    version,
+		Version:    Version,
 		HelpFunc:   cli.BasicHelpFunc(Name),
 		HelpWriter: os.Stdout,
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -1,0 +1,8 @@
+package command
+
+import "github.com/mitchellh/cli"
+
+// Meta contain the meta-option that nearly all subcommand inherited.
+type Meta struct {
+	Ui cli.Ui
+}

--- a/command/version-number.go
+++ b/command/version-number.go
@@ -1,0 +1,20 @@
+package command
+
+type VersionNumberCommand struct {
+	Meta
+
+	Version string
+}
+
+func (c *VersionNumberCommand) Run(args []string) int {
+	c.Ui.Output(c.Version)
+	return 0
+}
+
+func (c *VersionNumberCommand) Synopsis() string {
+	return ""
+}
+
+func (c *VersionNumberCommand) Help() string {
+	return ""
+}

--- a/command/version-number_test.go
+++ b/command/version-number_test.go
@@ -1,0 +1,11 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestVersionNumberCommand_implement(t *testing.T) {
+	var _ cli.Command = &VersionNumberCommand{}
+}

--- a/command/version.go
+++ b/command/version.go
@@ -1,0 +1,34 @@
+package command
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type VersionCommand struct {
+	Meta
+
+	Name     string
+	Version  string
+	Revision string
+}
+
+func (c *VersionCommand) Run(args []string) int {
+	var versionString bytes.Buffer
+
+	fmt.Fprintf(&versionString, "%s v%s", c.Name, c.Version)
+	if c.Revision != "" {
+		fmt.Fprintf(&versionString, " (%s)", c.Revision)
+	}
+
+	c.Ui.Output(versionString.String())
+	return 0
+}
+
+func (c *VersionCommand) Synopsis() string {
+	return fmt.Sprintf("Print %s version and quit", c.Name)
+}
+
+func (c *VersionCommand) Help() string {
+	return ""
+}

--- a/commands.go
+++ b/commands.go
@@ -10,14 +10,14 @@ func Commands(meta *command.Meta) map[string]cli.CommandFactory {
 		"version-number": func() (cli.Command, error) {
 			return &command.VersionNumberCommand{
 				Meta:    *meta,
-				Version: version,
+				Version: Version,
 			}, nil
 		},
 
 		"version": func() (cli.Command, error) {
 			return &command.VersionCommand{
 				Meta:     *meta,
-				Version:  version,
+				Version:  Version,
 				Revision: GitCommit,
 				Name:     Name,
 			}, nil

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/YOwatari/packer-post-processor-vagrant-metadata/command"
+	"github.com/mitchellh/cli"
+)
+
+func Commands(meta *command.Meta) map[string]cli.CommandFactory {
+	return map[string]cli.CommandFactory{
+		"version-number": func() (cli.Command, error) {
+			return &command.VersionNumberCommand{
+				Meta:    *meta,
+				Version: version,
+			}, nil
+		},
+
+		"version": func() (cli.Command, error) {
+			return &command.VersionCommand{
+				Meta:     *meta,
+				Version:  version,
+				Revision: GitCommit,
+				Name:     Name,
+			}, nil
+		},
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"github.com/mitchellh/packer/packer/plugin"
+	"os"
 )
 
-const version = "0.1.1"
-
 func main() {
+	if len(os.Args[1:]) != 0 {
+		os.Exit(Run(os.Args[1:]))
+	}
+
 	server, err := plugin.Server()
 	if err != nil {
 		panic(err)

--- a/metadata.go
+++ b/metadata.go
@@ -5,12 +5,12 @@ import (
 )
 
 type Metadata struct {
-	Name        string     `json:"name"`
-	Description string     `json:"discription"`
-	Versions    []*Version `json:"versions"`
+	Name        string        `json:"name"`
+	Description string        `json:"discription"`
+	Versions    []*BoxVersion `json:"versions"`
 }
 
-type Version struct {
+type BoxVersion struct {
 	Version   string      `json:"version"`
 	Providers []*Provider `json:"providers"`
 }
@@ -34,7 +34,7 @@ func (m *Metadata) Add(version string, provider *Provider) error {
 			return nil
 		}
 	}
-	m.Versions = append(m.Versions, &Version{
+	m.Versions = append(m.Versions, &BoxVersion{
 		Version:   version,
 		Providers: []*Provider{provider},
 	})

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package main
 
 const Name string = "packer-post-processor-vagrant-metadata"
-const version string = "0.1.1"
+const Version string = "0.1.1"
 
 // GitCommit describes latest commit hash.
 // This value is extracted by git command when building.

--- a/version.go
+++ b/version.go
@@ -1,0 +1,9 @@
+package main
+
+const Name string = "packer-post-processor-vagrant-metadata"
+const version string = "0.1.1"
+
+// GitCommit describes latest commit hash.
+// This value is extracted by git command when building.
+// To set this from outside, use go build -ldflags "-X main.GitCommit \"$(COMMIT)\""
+var GitCommit string

--- a/wercker.yml
+++ b/wercker.yml
@@ -11,7 +11,7 @@ build:
         name: go test
         code: |
           make test
-    - YOwatari/goveralls:
+    - yowatari/goveralls:
         token: $COVERALLS_TOKEN
 deploy:
   steps:

--- a/wercker.yml
+++ b/wercker.yml
@@ -11,7 +11,7 @@ build:
         name: go test
         code: |
           make test
-    - tcnksm/goveralls:
+    - YOwatari/goveralls:
         token: $COVERALLS_TOKEN
 deploy:
   steps:


### PR DESCRIPTION
command version

``` sh
$ packer-post-processor-vagrant-metadata version
packer-post-processor-vagrant-metadata v0.1.1 ("b0d14ac8d908cf4a72b0c191cc8e371f4ca18501")
```

command version-number (and no command with flag -v or -version or --version)

``` sh
$ packer-post-processor-vagrant-metadata version-number
0.1.1
$ packer-post-processor-vagrant-metadata -v
0.1.1
```
