### PR TITLE
Update packer package path

### DIFF
--- a/artifact_test.go
+++ b/artifact_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mitchellh/packer/packer"
+	"github.com/hashicorp/packer/packer"
 	"strings"
 	"testing"
 )

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/mitchellh/packer/packer/plugin"
+	"github.com/hashicorp/packer/packer/plugin"
 	"os"
 )
 

--- a/post-processor.go
+++ b/post-processor.go
@@ -11,10 +11,10 @@ import (
 	"path"
 	"strings"
 
-	"github.com/mitchellh/packer/common"
-	"github.com/mitchellh/packer/helper/config"
-	"github.com/mitchellh/packer/packer"
-	"github.com/mitchellh/packer/template/interpolate"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
 )
 
 type Config struct {

--- a/post-processor_test.go
+++ b/post-processor_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"github.com/mitchellh/packer/packer"
+	"github.com/hashicorp/packer/packer"
 	"io/ioutil"
 	"os"
 	"strings"


### PR DESCRIPTION
- packerパッケージのパスが変わったためか、ビルドに失敗してしまうため修正を行いました
- エラーメッセージは以下の通りです

```
$ git clone https://github.com/YOwatari/packer-post-processor-vagrant-metadata
$ cd packer-post-processor-vagrant-metadata
$ make
go get -d -t -v ./...
go test -v ./...
# _/Users/n-murata/work/packer-post-processor-vagrant-metadata
./main.go:17:46: cannot use PostProcessor literal (type *PostProcessor) as type "github.com/hashicorp/packer/packer".PostProcessor in argument to server.RegisterPostProcessor:
	*PostProcessor does not implement "github.com/hashicorp/packer/packer".PostProcessor (wrong type for PostProcess method)
		have PostProcess("github.com/mitchellh/packer/packer".Ui, "github.com/mitchellh/packer/packer".Artifact) ("github.com/mitchellh/packer/packer".Artifact, bool, error)
		want PostProcess("github.com/hashicorp/packer/packer".Ui, "github.com/hashicorp/packer/packer".Artifact) ("github.com/hashicorp/packer/packer".Artifact, bool, error)
./post-processor.go:41:21: cannot use &p.config.ctx (type *"github.com/mitchellh/packer/template/interpolate".Context) as type *"github.com/hashicorp/packer/template/interpolate".Context in field value
./post-processor.go:42:20: cannot use "github.com/mitchellh/packer/template/interpolate".RenderFilter literal (type *"github.com/mitchellh/packer/template/interpolate".RenderFilter) as type *"github.com/hashicorp/packer/template/interpolate".RenderFilter in field value
FAIL	_/Users/n-murata/work/packer-post-processor-vagrant-metadata [build failed]
=== RUN   TestVersionNumberCommand_implement
--- PASS: TestVersionNumberCommand_implement (0.00s)
PASS
ok  	_/Users/n-murata/work/packer-post-processor-vagrant-metadata/command	0.008s
make: *** [test] Error 2
```